### PR TITLE
wpewebkit: Don't set options unnecessarily

### DIFF
--- a/package/wpe/wpewebkit/wpewebkit.mk
+++ b/package/wpe/wpewebkit/wpewebkit.mk
@@ -16,12 +16,6 @@ WPEWEBKIT_DEPENDENCIES = host-ruby host-flex host-bison host-gperf \
 	harfbuzz icu jpeg libegl libepoxy libgcrypt libsecret libsoup libxml2 \
 	libxslt sqlite webp wpebackend
 WPEWEBKIT_CONF_OPTS = \
-	-DENABLE_API_TESTS=OFF \
-	-DENABLE_GEOLOCATION=OFF \
-	-DENABLE_GTKDOC=OFF \
-	-DENABLE_INTROSPECTION=OFF \
-	-DENABLE_MINIBROWSER=OFF \
-	-DENABLE_SPELLCHECK=OFF \
 	-DPORT=WPE
 
 # ARM needs NEON for JIT


### PR DESCRIPTION
None of these options are supported in WPE, and all are already set to
their default values, so there is no need to disable any of them.

Specifically:

 * ENABLE_API_TESTS already defaults to OFF except in DEVELOPER_MODE,
and changing it is not supported.
 * ENABLE_GEOLOCATION defaults to OFF, and enabling it is not supported.
 * ENABLE_GTKDOC and ENABLE_INTROSPECTION are GTK-only options that do
not exist for WPE. When they are added, ENABLE_GTKDOC will almost surely
be disabled by default. ENABLE_INTROSPECTION will probably be enabled,
but it seems pretty aggressive to disable options that do not yet exist
in anticipation of them being added in the future.
 * ENABLE_MINIBROWSER defaults to OFF, and enabling it is not supported.
 * ENABLE_SPELLCHECK defaults to OFF, and enabling it is not supported.